### PR TITLE
Fixes styleguide link from /kss

### DIFF
--- a/app/views/kss/home/index.html.erb
+++ b/app/views/kss/home/index.html.erb
@@ -1,2 +1,2 @@
 <h1>Welcome!</h1>
-<p>This is an example <a href="/styleguide">styleguide</a>. To customize this page, create a file at <code>app/views/kss/home/index.html.erb</code>.</p>
+<p>This is an example <a href="./styleguide">styleguide</a>. To customize this page, create a file at <code>app/views/kss/home/index.html.erb</code>.</p>


### PR DESCRIPTION
Nothing found at `/styleguide`. This should like to `/kss/styleguide` (or to `styleguide` in wherever `kss` was mounted).
