### PR TITLE
Remove reset CSS code

### DIFF
--- a/app/assets/stylesheets/kss.css.scss
+++ b/app/assets/stylesheets/kss.css.scss
@@ -1,36 +1,5 @@
-/*----------------------------------------------------------------------------
-  @group Global Reset
-----------------------------------------------------------------------------*/
-* {
-  padding:0;
-  margin:0;
-}
-h1, h2, h3, h4, h5, h6, p, pre, blockquote, label, ul, ol, dl, fieldset, address { margin:1em 0; }
-li, dd { margin-left:5%; }
-fieldset { padding: .5em; }
-select option{ padding:0 5px; }
-
-.access{ display:none; } /* For accessibility related elements */
-.clear{ clear:both; height:0px; font-size:0px; line-height:0px; overflow:hidden; }
-a{ outline:none; }
-a img{ border:none; }
-
-.clearfix:after {
-    content: ".";
-    display: block;
-    height: 0;
-    clear: both;
-    visibility: hidden;
-}
-* html .clearfix {height: 1%;}
-.clearfix {display:inline-block;}
-.clearfix {display: block;}
-
-/* @end */
-
-body{
-  font-family:Helvetica, Arial, sans-serif;
-  font-size:14px;
+.kss-body {
+  margin: 0;
 }
 
 .kss-header{
@@ -138,5 +107,3 @@ h1.styleguide {
       color: #222; }
 
 /* @end */
-
-//= require application

--- a/lib/generators/templates/application.html.erb
+++ b/lib/generators/templates/application.html.erb
@@ -7,7 +7,7 @@
     <%= stylesheet_link_tag 'application' %>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
-  <body>
+  <body class="kss-body">
     <header class="kss-header">
       KSS Styleguide Example
     </header>


### PR DESCRIPTION
I understand why you've put the reset.css code in `kss.css.scss`, but this can affect the elements you are building within the style guide. I had this problem with several implementations of kss-rails. 

I also removed the `//= require application` from the `kss.css.scss` file, I think this is something the user should do manually. When I use kss-rails I always include the css files in the `application.html.erb` layout. This is a little bit to automagic to my taste.. :smile: 

I hope you can merge this pull request.
