### PR TITLE
Show error to tell developer they added a styleguide block for an undefined section

### DIFF
--- a/app/helpers/kss/application_helper.rb
+++ b/app/helpers/kss/application_helper.rb
@@ -8,7 +8,9 @@ module Kss
       
       @section = styleguide.section(section)
 
-      raise "KSS styleguide section is nil, is section: '#{section}' defined in your css?" unless @section.raw
+      if !@section.raw
+          raise "KSS styleguide section is nil, is section '#{section}' defined in your css?"
+      end
 
       content = capture(&block)
       render 'kss/shared/styleguide_block', :section => @section, :example_html => content

--- a/app/helpers/kss/application_helper.rb
+++ b/app/helpers/kss/application_helper.rb
@@ -7,6 +7,9 @@ module Kss
       raise ArgumentError, "Missing block" unless block_given?
       
       @section = styleguide.section(section)
+
+      raise "KSS styleguide section is nil, is section: '#{section}' defined in your css?" unless @section.raw
+
       content = capture(&block)
       render 'kss/shared/styleguide_block', :section => @section, :example_html => content
     end


### PR DESCRIPTION
This pull request adds an error when a developer adds a section that isn't defined in css yet. I've had this question several times in my team. 

![Undefined styleguide element](https://f.cloud.github.com/assets/167882/117470/f30e44b6-6c3f-11e2-93f3-adc5928761cd.png)
