### PR TITLE
Support focus & checked psuedo classes

### DIFF
--- a/app/assets/javascripts/kss.coffee
+++ b/app/assets/javascripts/kss.coffee
@@ -1,7 +1,7 @@
 # This class scans your stylesheets for pseudo classes, then inserts a new CSS
 # rule with the same properties, but named 'psuedo-class-{{name}}'.
 #
-# Supported pseudo classes: hover, disabled, active, visited.
+# Supported pseudo classes: hover, disabled, active, visited, focus, checked.
 #
 # Example:
 #
@@ -9,7 +9,7 @@
 #   => a.pseudo-class-hover{ color:blue; }
 class KssStateGenerator
   constructor: ->
-    pseudos = /(\:hover|\:disabled|\:active|\:visited)/g
+    pseudos = /(\:hover|\:disabled|\:active|\:visited|\:focus|\:checked)/g
 
     try
       for stylesheet in document.styleSheets


### PR DESCRIPTION
This patch adds support for the `:focus` and `:checked` psuedo classes in the styleguide.
