### PR TITLE
Fix link path to styleguide in index.html.erb

### DIFF
--- a/lib/generators/templates/index.html.erb
+++ b/lib/generators/templates/index.html.erb
@@ -1,2 +1,2 @@
 <h1>Welcome!</h1>
-<p>This is an example <a href="/styleguide">styleguide</a>. To customize this page, create a file at <code>app/views/kss/home/index.html.erb</code>.</p>
+<p>This is an example <%= link_to 'Styleguide', kss.styleguide_path %>. To customize this page, create a file at <code>app/views/kss/home/index.html.erb</code>.</p>


### PR DESCRIPTION
Old path is '/styleguide', but correct path is '/kss/styleguide' if I mount like following.

```
# in config/routes.rb
mount Kss::Engine => '/kss' if Rails.env.development?
```

So I Changed to use dynamic helper as used in application.html.erb.
