### PR TITLE
Adding Styleguide Entry helper.

### DIFF
--- a/app/helpers/kss/application_helper.rb
+++ b/app/helpers/kss/application_helper.rb
@@ -1,5 +1,3 @@
-require 'ostruct'
-
 module Kss
   module ApplicationHelper
     # Generates a styleguide block. A little bit evil with @_out_buf, but
@@ -20,18 +18,8 @@ module Kss
 
     def styleguide_entry(section)
       @section = styleguide.section(section)
-      @section = missing_entry(section) unless @section.raw
-
+      binding.pry
       render 'kss/shared/styleguide_entry', :section => @section
-    end
-
-    private
-    def missing_entry(section)
-      OpenStruct.new({
-        :section => section,
-        :filename => nil,
-        :description => "Section \"#{section}\" has not yet been created. Please add documentation for this section in your styles."
-      })
     end
   end
 end

--- a/app/helpers/kss/application_helper.rb
+++ b/app/helpers/kss/application_helper.rb
@@ -15,5 +15,15 @@ module Kss
       content = capture(&block)
       render 'kss/shared/styleguide_block', :section => @section, :example_html => content
     end
+
+    def styleguide_entry(section)
+      raise ArgumentError, 'Missing Entry' unless section
+
+      @section = styleguide.section(section)
+
+      raise "KSS Styleguide section is nil, is section '#{section}' defined in your css?" unless @section.raw
+
+      render 'kss/shared/styleguide_entry', :section => @section
+    end
   end
 end

--- a/app/helpers/kss/application_helper.rb
+++ b/app/helpers/kss/application_helper.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 module Kss
   module ApplicationHelper
     # Generates a styleguide block. A little bit evil with @_out_buf, but
@@ -18,7 +20,7 @@ module Kss
 
     def styleguide_entry(section)
       @section = styleguide.section(section)
-      binding.pry
+      @section = OpenStruct.new({section: section}) unless @section.raw
       render 'kss/shared/styleguide_entry', :section => @section
     end
   end

--- a/app/helpers/kss/application_helper.rb
+++ b/app/helpers/kss/application_helper.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 module Kss
   module ApplicationHelper
     # Generates a styleguide block. A little bit evil with @_out_buf, but
@@ -17,13 +19,19 @@ module Kss
     end
 
     def styleguide_entry(section)
-      raise ArgumentError, 'Missing Entry' unless section
-
       @section = styleguide.section(section)
-
-      raise "KSS Styleguide section is nil, is section '#{section}' defined in your css?" unless @section.raw
+      @section = missing_entry(section) unless @section.raw
 
       render 'kss/shared/styleguide_entry', :section => @section
+    end
+
+    private
+    def missing_entry(section)
+      OpenStruct.new({
+        :section => section,
+        :filename => nil,
+        :description => "Section \"#{section}\" has not yet been created. Please add documentation for this section in your styles."
+      })
     end
   end
 end

--- a/app/views/kss/shared/_styleguide_entry.erb
+++ b/app/views/kss/shared/_styleguide_entry.erb
@@ -1,0 +1,6 @@
+<div class="styleguide-example">
+  <h3><%= section.section %> <em><%= section.filename %></em></h3>
+  <div class="styleguide-description">
+    <p><%= section.description %></p>
+  </div>
+</div>

--- a/app/views/kss/shared/_styleguide_entry.erb
+++ b/app/views/kss/shared/_styleguide_entry.erb
@@ -1,6 +1,13 @@
-<div class="styleguide-example<% unless section.filename.nil? then ' pending' end %>">
-  <h3><%= section.section %><% unless section.filename.nil? %> <em><%= section.filename %></em><% end %></h3>
-  <div class="styleguide-description">
-    <p><%= section.description %></p>
-  </div>
+<div class="styleguide-example<%= unless section.raw then ' pending' end %>">
+  <% if section.raw %>
+    <h3><%= section.section %> <em><%= section.filename %></h3>
+    <div class="styleguide-description">
+      <%= section.description %>
+    </div>
+  <% else %>
+    <h3><%= section.section %></h3>
+    <p>
+      Section <%= section.section %> has not yet been created. Please add documentation for this section.
+    </p>
+  <% end %>
 </div>

--- a/app/views/kss/shared/_styleguide_entry.erb
+++ b/app/views/kss/shared/_styleguide_entry.erb
@@ -1,5 +1,5 @@
-<div class="styleguide-example">
-  <h3><%= section.section %> <em><%= section.filename %></em></h3>
+<div class="styleguide-example<% unless section.filename.nil? then ' pending' end %>">
+  <h3><%= section.section %><% unless section.filename.nil? %> <em><%= section.filename %></em><% end %></h3>
   <div class="styleguide-description">
     <p><%= section.description %></p>
   </div>


### PR DESCRIPTION
In cases where there is CSS / SCSS documentation that does not directly correlate to an element, it would be nice to have a helper to simply output the text of the documentation like:

``` haml
  = styleguide_entry '1.1'
```
