### PR TITLE
Remove $modifier_class from stylegude-element

### DIFF
--- a/app/views/kss/shared/_styleguide_block.erb
+++ b/app/views/kss/shared/_styleguide_block.erb
@@ -11,7 +11,7 @@
     <% end %>
   </div>
   <div class="styleguide-element">
-    <%= example_html.html_safe %>
+    <%= example_html.gsub('$modifier_class','').html_safe %>
   </div>
   <pre><code data-language="html"><%= example_html.strip %></code></pre>
   <% section.modifiers.each do |modifier| %>


### PR DESCRIPTION
Remove $modifier_class from examle_html.

This is copy from KSS official sample code.
http://warpspire.com/kss/styleguides/
